### PR TITLE
refactor: Rename Egypt visa application router to avoid naming conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ import egyptPaymentRouter from './routes/egyptN/egyptPaymentRoutes.js';
 import egyptGovRefDetailsRouter from './routes/egyptN/egyptGovRefDetailsRoute.js';
 import egyptDeclarationRouter from './routes/egyptN/egyptDeclarationRoutes.js';
 import egyptEmailRouter from './routes/egyptN/egyptEmailRoutes.js';
+import egyptVisaApplicationRouterN from './routes/egyptN/egyptVisaApplicationRoute.js';
 
 dotenv.config();
 dbConnect();
@@ -203,7 +204,7 @@ app.use('/api/v1/kenya-visa/declarations', kenyaDeclarationRouter);
 app.use('/api/v1/kenya-visa/mail', kenyaEmailRouter);
 
 // Egypt Visa Routes
-app.use('/api/v1/egypt-visa', egyptVisaApplicationRouter);
+app.use('/api/v1/egypt-visa', egyptVisaApplicationRouterN);
 app.use('/api/v1/egypt-visa/documents', egyptDocumentsRoute);
 app.use('/api/v1/egypt-visa/payments', egyptPaymentRouter);
 app.use('/api/v1/egypt-visa/gov-ref', egyptGovRefDetailsRouter);

--- a/routes/egyptN/egyptVisaApplicationRoute.js
+++ b/routes/egyptN/egyptVisaApplicationRoute.js
@@ -6,127 +6,127 @@ import egyptPersonalInfoController from '../../controllers/egyptN/egyptPersonalI
 import egyptPassportInfoController from '../../controllers/egyptN/egyptPassportInfoController.js';
 import egyptAdditionalApplicantsController from '../../controllers/egyptN/egyptAdditionalApplicantsController.js';
 
-const egyptVisaApplicationRouter = express.Router();
+const egyptVisaApplicationRouterN = express.Router();
 
 // Main application routes
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/all',
   egyptVisaApplicationController.getAllEgyptVisaApplications
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/:id',
   egyptVisaApplicationController.getEgyptVisaApplicationById
 );
 
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/check-status',
   egyptVisaApplicationController.checkApplicationStatus
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/:id',
   egyptVisaApplicationController.updateEgyptVisaApplication
 );
 
-egyptVisaApplicationRouter.delete(
+egyptVisaApplicationRouterN.delete(
   '/:id',
   egyptVisaApplicationController.deleteEgyptVisaApplication
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/:id/applicants',
   egyptVisaApplicationController.getAllApplicantsDetails
 );
 
 // Visa details routes
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/visa-details',
   egyptVisaDetailsController.createEgyptVisaDetails
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/visa-details/:formId',
   egyptVisaDetailsController.getEgyptVisaDetailsByFormId
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/visa-details/:formId',
   egyptVisaDetailsController.updateEgyptVisaDetails
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/visa-types/prices',
   egyptVisaDetailsController.getVisaTypesAndPrices
 );
 
 // Arrival info routes
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/arrival-info',
   egyptArrivalInfoController.createEgyptArrivalInfo
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/arrival-info/:formId',
   egyptArrivalInfoController.getEgyptArrivalInfoByFormId
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/arrival-info/:formId',
   egyptArrivalInfoController.updateEgyptArrivalInfo
 );
 
 // Personal info routes
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/personal-info',
   egyptPersonalInfoController.createEgyptPersonalInfo
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/personal-info/:formId',
   egyptPersonalInfoController.getEgyptPersonalInfoByFormId
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/personal-info/:formId',
   egyptPersonalInfoController.updateEgyptPersonalInfo
 );
 
 // Passport info routes
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/passport-info',
   egyptPassportInfoController.createEgyptPassportInfo
 );
 
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/passport-info/:formId',
   egyptPassportInfoController.getEgyptPassportInfoByFormId
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/passport-info/:formId',
   egyptPassportInfoController.updateEgyptPassportInfo
 );
 
 // Additional Applicants
-egyptVisaApplicationRouter.get(
+egyptVisaApplicationRouterN.get(
   '/additional-applicants/:formId',
   egyptAdditionalApplicantsController.getAdditionalApplicants
 );
 
-egyptVisaApplicationRouter.post(
+egyptVisaApplicationRouterN.post(
   '/additional-applicants/:formId',
   egyptAdditionalApplicantsController.addAdditionalApplicant
 );
 
-egyptVisaApplicationRouter.put(
+egyptVisaApplicationRouterN.put(
   '/additional-applicants/:formId/:applicantIndex',
   egyptAdditionalApplicantsController.updateAdditionalApplicant
 );
 
-egyptVisaApplicationRouter.delete(
+egyptVisaApplicationRouterN.delete(
   '/additional-applicants/:formId/:applicantIndex',
   egyptAdditionalApplicantsController.removeAdditionalApplicant
 );
 
-export default egyptVisaApplicationRouter;
+export default egyptVisaApplicationRouterN;


### PR DESCRIPTION
- Renamed `egyptVisaApplicationRouter` to `egyptVisaApplicationRouterN` in `routes/egyptN/egyptVisaApplicationRoute.js` to avoid potential naming conflicts.
- Updated the import and usage of the router in `index.js` to reflect the new name.